### PR TITLE
Support multiple files on command line in "selected files mode"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -219,3 +219,6 @@ FakesAssemblies/
 GeneratedArtifacts/
 _Pvt_Extensions/
 ModelManifest.xml
+
+vcredistx64.exe
+

--- a/README.md
+++ b/README.md
@@ -1,13 +1,20 @@
 # ShadowDuplicator
 
-Rudimentary Volume Shadow Copy backup client which (non-recursively) copies files from a source directory to
-a destination directory, having first created a Volume Shadow Copy. Useful for backing up files which are typically
-locked for reading.
+Command line Volume Shadow Copy backup client which has two modes:
 
-Perhaps this is even just a useful substitute for the lack of a `vssadmin create shadow` command on Windows client SKUs. ;)
+ * (non-recursively) copies files from a source directory to a destination directory (provide an INI file to configure)
+ * copies selected files provided on the command line to the destination directory (last command line argument)
 
-ShadowDuplicator is written in C++, working directly with the Volume Shadow Copy API and other Win32 APIs for copying files. The
-software is configured using simple INI files.
+This is useful for backing up files which are typically locked for reading and creating crash-consistent
+copies of content, for example virtual machine hard disk files without shutting the VMs down.
+
+Perhaps this is even just a useful substitute for the lack of a `vssadmin create shadow` command on Windows
+client SKUs. 😉
+
+ShadowDuplicator is written in C++, working directly with the Volume Shadow Copy API and other Win32 APIs for copying files.
+
+This software comes with no warranty and no assumptions should be made about its stability or fitness
+for any particular purpose.
 
 ## Licence
 
@@ -16,20 +23,21 @@ Apache 2.0. Please see `LICENSE`.
 ## Usage
 
     Usage: ShadowDuplicator.exe [OPTIONS] INI-FILE
-    or single file mode:
-    Usage: ShadowDuplicator.exe -s [SOURCE] [DEST_DIRECTORY_AND_FILENAME]
+    
+    or selected files mode:
 
-    Multi File Example:  ShadowDuplicator.exe -q BackupConfig.ini
-    Single File Example: ShadowDuplicator.exe -q -s SourceFile.txt D:\DestDirectory\DestFile.txt
+    Usage: ShadowDuplicator.exe -s SOURCE [SOURCE2 [SOURCE3] ...] DEST_DIRECTORY
 
+    Whole Folder Mode Example:  ShadowDuplicator.exe -q BackupConfig.ini
+    Selected Files Example: ShadowDuplicator.exe -q -s SourceFile.txt SourceFile2.txt D:\DestDirectory
 
 
     Options:
     -h, --help, -?, /?, --usage     Print this help message
     -q                              Silence the banner and any progress messages
-    -s, --singlefile                Single file mode -- copy one source file to the destination directory only
+    -s, --selected                  Selected files mode -- copy source files to the destination directory (the last command line argument)
 
-    The path to the INI file must not begin with '-'.
+    The path to the INI file or any source file must not begin with '-'.
     The INI file should be as follows:
 
     [FileSet]
@@ -37,10 +45,9 @@ Apache 2.0. Please see `LICENSE`.
     Destination = D:\test
     Do not include trailing slashes in paths.
 
-    In single-file mode, you must provide the full destination path, including destination file name in the
-    directory.
+    In selected-files mode, you must provide the destination directory path only.
 
-    WARNING: Copies will always overwrite items in the destination.
+    WARNING: Copies will always overwrite items in the destination without confirmation.
 
 Please install the [latest supported Visual C++ redistributable (x64)](https://docs.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#visual-studio-2015-2017-2019-and-2022) before trying to launch.
 
@@ -61,8 +68,7 @@ conditions:
 | 0x20000002 | 536870914  | SDEXIT_NO_FIRST_FILE_IN_SOURCE           | Could not find any files in the source directory.      |
 | 0x20000003 | 536870915  | SDEXIT_NO_SOURCE_SPECIFIED               | No source file or directory specified on command line. |
 | 0x20000004 | 536870916  | SDEXIT_SOURCE_FILES_ON_DIFFERENT_VOLUMES | All source files must be on the same volume. This error is returned if this constraint is violated. |
-
-SDEXIT_SOURCE_FILES_ON_DIFFERENT_VOLUMES 4 | 0x20000000
+| 0x20000005 | 536870917  | SDEXIT_INVALID_ARGS                      | Arguments could not be parsed from command line. Usage message will have been displayed. |
 
 ## Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -55,11 +55,14 @@ have been completed successfully.
 Additionally, the following exit codes are specific to ShadowDuplicator and indicate the following
 conditions:
 
-| Code (hex) | Code (dec) | Constant                       | Meaning                                                |
-| ---------- | ---------- | ------------------------------ | ------------------------------------------------------ |
-| 0x20000001 | 536870913  | SDEXIT_NO_DEST_DIR_SPECIFIED   | No destination directory specified on command line.    |
-| 0x20000002 | 536870914  | SDEXIT_NO_FIRST_FILE_IN_SOURCE | Could not find any files in the source directory.      |
-| 0x20000003 | 536870915  | SDEXIT_NO_SOURCE_SPECIFIED     | No source file or directory specified on command line. |
+| Code (hex) | Code (dec) | Constant                                 | Meaning                                                |
+| ---------- | ---------- | ---------------------------------------- | ------------------------------------------------------ |
+| 0x20000001 | 536870913  | SDEXIT_NO_DEST_DIR_SPECIFIED             | No destination directory specified on command line.    |
+| 0x20000002 | 536870914  | SDEXIT_NO_FIRST_FILE_IN_SOURCE           | Could not find any files in the source directory.      |
+| 0x20000003 | 536870915  | SDEXIT_NO_SOURCE_SPECIFIED               | No source file or directory specified on command line. |
+| 0x20000004 | 536870916  | SDEXIT_SOURCE_FILES_ON_DIFFERENT_VOLUMES | All source files must be on the same volume. This error is returned if this constraint is violated. |
+
+SDEXIT_SOURCE_FILES_ON_DIFFERENT_VOLUMES 4 | 0x20000000
 
 ## Disclaimer
 

--- a/ShadowDuplicator.cpp
+++ b/ShadowDuplicator.cpp
@@ -372,10 +372,8 @@ int wmain(int argc, WCHAR** argv)
     do {
         assert(currentSourceFilename->source != nullptr);
         if (!PathFileExistsW(currentSourceFilename->source)) {
-            error = GetLastError();
-            if (error) {
-                friendlyError(L"The source file does not seem to exist.", error); //friendlyError will bail //TODO say which file
-            }
+            wprintf(L"The source file \"%s\" does not seem to exist. 0x%x\n", currentSourceFilename->source, GetLastError());
+            bail(GetLastError());
         }
         currentSourceFilename = currentSourceFilename->next;
     } while (currentSourceFilename != nullptr);

--- a/ShadowDuplicator.h
+++ b/ShadowDuplicator.h
@@ -1,7 +1,7 @@
 /* ShadowDuplicator -- a simple VC++ Volume Shadow Copy requestor for backing up
 locked files
 
-Copyright (C) 2021 Peter Upfold.
+Copyright (C) 2021-22 Peter Upfold.
 
 Licensed under the Apache 2.0 Licence. See the LICENSE file in the project root for details.
 

--- a/ShadowDuplicator.h
+++ b/ShadowDuplicator.h
@@ -37,3 +37,4 @@ LPPROGRESS_ROUTINE copyProgress(
 	LPVOID lpData
 );
 void VerifyWriterStatus(void);
+void FreeSourceStructures(void);

--- a/ShadowDuplicator.sln
+++ b/ShadowDuplicator.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31515.178
+# Visual Studio Version 17
+VisualStudioVersion = 17.4.33103.184
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ShadowDuplicator", "ShadowDuplicator.vcxproj", "{735FACBB-A9B2-4566-87EA-BB6A94215A31}"
 EndProject
@@ -9,6 +9,8 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
+		FolderMode|x64 = FolderMode|x64
+		FolderMode|x86 = FolderMode|x86
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
@@ -17,6 +19,10 @@ Global
 		{735FACBB-A9B2-4566-87EA-BB6A94215A31}.Debug|x64.Build.0 = Debug|x64
 		{735FACBB-A9B2-4566-87EA-BB6A94215A31}.Debug|x86.ActiveCfg = Debug|Win32
 		{735FACBB-A9B2-4566-87EA-BB6A94215A31}.Debug|x86.Build.0 = Debug|Win32
+		{735FACBB-A9B2-4566-87EA-BB6A94215A31}.FolderMode|x64.ActiveCfg = FolderMode|x64
+		{735FACBB-A9B2-4566-87EA-BB6A94215A31}.FolderMode|x64.Build.0 = FolderMode|x64
+		{735FACBB-A9B2-4566-87EA-BB6A94215A31}.FolderMode|x86.ActiveCfg = FolderMode|Win32
+		{735FACBB-A9B2-4566-87EA-BB6A94215A31}.FolderMode|x86.Build.0 = FolderMode|Win32
 		{735FACBB-A9B2-4566-87EA-BB6A94215A31}.Release|x64.ActiveCfg = Release|x64
 		{735FACBB-A9B2-4566-87EA-BB6A94215A31}.Release|x64.Build.0 = Release|x64
 		{735FACBB-A9B2-4566-87EA-BB6A94215A31}.Release|x86.ActiveCfg = Release|Win32

--- a/ShadowDuplicator.vcxproj
+++ b/ShadowDuplicator.vcxproj
@@ -5,6 +5,14 @@
       <Configuration>Debug</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="FolderMode|Win32">
+      <Configuration>FolderMode</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="FolderMode|x64">
+      <Configuration>FolderMode</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|Win32">
       <Configuration>Release</Configuration>
       <Platform>Win32</Platform>
@@ -32,6 +40,12 @@
     <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='FolderMode|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
@@ -40,6 +54,12 @@
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='FolderMode|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
@@ -60,10 +80,16 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='FolderMode|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='FolderMode|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -73,16 +99,36 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='FolderMode|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='FolderMode|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>vssapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <UACExecutionLevel>RequireAdministrator</UACExecutionLevel>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='FolderMode|Win32'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
@@ -113,6 +159,20 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>vssapi.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <UACExecutionLevel>RequireAdministrator</UACExecutionLevel>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='FolderMode|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>


### PR DESCRIPTION
This approach refactors the code to work (almost entirely) with wide strings, but most importantly, allows for the backing up of multiple individual files in "selected files mode" (replacing "single file mode", although this is still possible by just providing a single source).

Backing up multiple individual files from the same crash-consistent VSS snapshot is highly useful for backing up a virtual machine with multiple VHDX disks from the same point in time, without requiring the back up of an entire folder.